### PR TITLE
Refact dialog view

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "semi": true,
+  "semi": false,
   "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "es5",

--- a/src/common/types/dialogs.ts
+++ b/src/common/types/dialogs.ts
@@ -1,9 +1,9 @@
-import { StoredItem } from "src/services/supabase/types"
+import { StoredItemMapped } from "src/services/supabase/types"
 
 type UserMessageContent = {
   type: 'user-message'
   text: string
-  stored_items: StoredItem[]
+  stored_items: StoredItemMapped[]
 }
 
 type AssistantMessageContent = {

--- a/src/components/AddInfoBtn.vue
+++ b/src/components/AddInfoBtn.vue
@@ -50,7 +50,7 @@
 import { useQuasar } from 'quasar'
 import { useCallApi } from 'src/composables/call-api'
 import { ApiResultItem, AssistantPlugins, Plugin, PluginApi } from 'src/utils/types'
-import { Dialog, Workspace } from '@/services/supabase/types'
+import { DialogMapped, WorkspaceMapped } from '@/services/supabase/types'
 import { computed, inject, Ref } from 'vue'
 import JsonInputDialog from './JsonInputDialog.vue'
 import { useI18n } from 'vue-i18n'
@@ -60,8 +60,8 @@ const props = defineProps<{
   assistantPlugins: AssistantPlugins
 }>()
 
-const workspace = inject<Ref<Workspace>>('workspace')
-const dialog = inject<Ref<Dialog>>('dialog')
+const workspace = inject<Ref<WorkspaceMapped>>('workspace')
+const dialog = inject<Ref<DialogMapped>>('dialog')
 
 const pluginInfos = computed<{ plugin: Plugin, apis: PluginApi[] }[]>(() =>
   props.plugins.map(p => ({
@@ -76,7 +76,7 @@ const pluginInfos = computed<{ plugin: Plugin, apis: PluginApi[] }[]>(() =>
 )
 
 const $q = useQuasar()
-const { callApi } = useCallApi({ workspace, dialog })
+const { callApi } = useCallApi(workspace, dialog)
 const { t } = useI18n()
 
 function handleResult(res: Awaited<ReturnType<typeof callApi>>) {

--- a/src/components/CyberlinkResult.vue
+++ b/src/components/CyberlinkResult.vue
@@ -28,14 +28,13 @@ import { parseEvents } from 'src/services/kepler/utils'
 import { IsTauri } from 'src/utils/platform-api'
 import { computed, ComputedRef, inject } from 'vue'
 
-import { DialogMessageMapped } from '@/services/supabase/types'
+import { DialogMessageMapped, StoredItemMapped } from '@/services/supabase/types'
 import { useDialogsStore } from 'src/stores/dialogs'
 
-const props = defineProps<{ result: any, message: DialogMessageMapped }>()
-const itemMap = inject<ComputedRef>('itemMap')
+const props = defineProps<{ result: StoredItemMapped[], message: DialogMessageMapped }>()
 const keplrWallet = inject<KeplerWallet>('kepler')
 const cosmosWallet = inject<CosmosWallet>('cosmos')
-const transactionBody = computed(() => JSON.parse(itemMap.value[props.result[0]].contentText))
+const transactionBody = computed(() => JSON.parse(props.result[0].content_text))
 const dialogsStore = useDialogsStore()
 const handleAccept = async () => {
   const { message_contents } = props.message

--- a/src/components/MessageFile.vue
+++ b/src/components/MessageFile.vue
@@ -12,13 +12,13 @@
 
 <script setup lang="ts">
 import { useQuasar } from 'quasar'
-import { StoredItem } from '@/services/supabase/types'
+import { StoredItemMapped } from '@/services/supabase/types'
 import ViewFileDialog from './ViewFileDialog.vue'
 import { computed } from 'vue'
 import { codeExtensions } from 'src/utils/values'
 
 const props = defineProps<{
-  file: StoredItem,
+  file: StoredItemMapped,
   removable?: boolean
 }>()
 

--- a/src/components/MessageItem.vue
+++ b/src/components/MessageItem.vue
@@ -123,13 +123,13 @@
             <message-image
               v-for="image in content.stored_items.filter(i => i.mime_type?.startsWith('image/'))"
               :key="image.id"
-              :image="image as StoredItemMapped"
+              :image="image"
               h="100px"
             />
             <message-file
               v-for="file in content.stored_items.filter(i => !i.mime_type?.startsWith('image/'))"
               :key="file.id"
-              :file="file as StoredItem"
+              :file="file"
             />
           </div>
           <tool-content
@@ -140,7 +140,7 @@
           />
           <CyberlinkResult
             v-if="message.status !== 'processed' && content.type === 'assistant-tool' && content.name === 'create_cyberlink' && content.status === 'completed'"
-            :result="content.result"
+            :result="content.stored_items"
             :message="message"
             :key="'cyberlink-' + index"
             class="my-2"

--- a/src/components/ToolContent.vue
+++ b/src/components/ToolContent.vue
@@ -89,7 +89,7 @@ import MessageImage from './MessageImage.vue'
 import MessageAudio from './MessageAudio.vue'
 import { useMdPreviewProps } from 'src/composables/md-preview-props'
 import { useI18n } from 'vue-i18n'
-import { StoredItem } from '@/services/supabase/types'
+import { StoredItemMapped } from '@/services/supabase/types'
 
 const { t } = useI18n()
 
@@ -128,7 +128,7 @@ const contentMd = computed(() => {
   return engine.parseAndRenderSync(contentTemplate, {
     content,
     result: content.result?.map(item => {
-      const { name = '', type, mime_type, content_text } = item as StoredItem
+      const { name = '', type, mime_type, content_text } = item as StoredItemMapped
       return { name, type, mime_type, content_text }
     })
   })

--- a/src/composables/call-api.ts
+++ b/src/composables/call-api.ts
@@ -2,10 +2,11 @@ import { usePluginsStore } from 'src/stores/plugins'
 import { Schema, Validator } from '@cfworker/json-schema'
 import { ApiResultItem, Plugin, PluginApi } from 'src/utils/types'
 import { removeUndefinedProps } from 'src/utils/functions'
-import { toRaw } from 'vue'
+import { Ref, toRaw } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { DialogMapped, WorkspaceMapped } from '@/services/supabase/types'
 
-export function useCallApi({ workspace, dialog }) {
+export function useCallApi(workspace: Ref<WorkspaceMapped>, dialog: Ref<DialogMapped>) {
   const pluginsStore = usePluginsStore()
   const { t } = useI18n()
 
@@ -22,7 +23,7 @@ export function useCallApi({ workspace, dialog }) {
     return { valid, settings }
   }
 
-  async function callApi(plugin: Plugin, api: PluginApi, args): Promise<{ result?: ApiResultItem[], error?: string }> {
+  async function callApi(plugin: Plugin, api: PluginApi, args: Record<string, any>): Promise<{ result?: ApiResultItem[], error?: string }> {
     const { valid: argValid } = new Validator(api.parameters as Schema).validate(args)
     if (!argValid) {
       return { result: [], error: t('callApi.argValidationFailed') }
@@ -39,5 +40,5 @@ export function useCallApi({ workspace, dialog }) {
       return { result: [], error: e.message }
     }
   }
-  return { getPluginSettings, callApi }
+  return { callApi }
 }

--- a/src/composables/call-api.ts
+++ b/src/composables/call-api.ts
@@ -34,7 +34,6 @@ export function useCallApi(workspace: Ref<WorkspaceMapped>, dialog: Ref<DialogMa
     }
     try {
       const result = await api.execute(args, settings)
-      console.log("---callApi result", result)
       return { result, error: null }
     } catch (e) {
       return { result: [], error: e.message }

--- a/src/composables/llm/useAssistantTools.ts
+++ b/src/composables/llm/useAssistantTools.ts
@@ -50,9 +50,29 @@ export const useAssistantTools = (assistant: Ref<AssistantMapped>, workspace: Re
     }
   }
 
+  function apiResultToToolResultContent(items: ApiResultItem[]) {
+    const val = []
+    for (const item of items) {
+      if (!item) continue // TODO: in case if tool failed ignore it
+      const { contentText, mimeType, contentBuffer } = item
+      if (item.type === 'text') {
+        val.push({ type: 'text', contentText })
+      } else if (mimeTypeMatch(mimeType, model.value.inputTypes.tool)) {
+        val.push({
+          type: mimeType?.startsWith('image/') ? 'image' : 'file',
+          mimeType,
+          data: contentBuffer || null
+        })
+      }
+    }
+
+    return val
+  }
+
   function toToolResultContent(items: (ApiResultItem | StoredItem)[]) {
     const val = []
     for (const item of items) {
+      console.log("-----toToolResultContent item", item)
       if (!item) continue // TODO: in case if tool failed ignore it
       if (item.type === 'text') {
         // Handle both ApiResultItem (contentText) and StoredItem (content_text)
@@ -83,7 +103,7 @@ export const useAssistantTools = (assistant: Ref<AssistantMapped>, workspace: Re
         if (error) throw new ApiCallError(error)
         return result
       },
-      experimental_toToolResultContent: toToolResultContent
+      experimental_toToolResultContent: apiResultToToolResultContent
     })
   }
 
@@ -154,6 +174,7 @@ export const useAssistantTools = (assistant: Ref<AssistantMapped>, workspace: Re
 
   return {
     getAssistantTools,
-    toToolResultContent
+    toToolResultContent,
+    apiResultToToolResultContent
   }
 }

--- a/src/composables/llm/useAssistantTools.ts
+++ b/src/composables/llm/useAssistantTools.ts
@@ -1,0 +1,159 @@
+import { engine } from "src/utils/template-engine"
+import { PluginPrompt, AssistantPlugins, Plugin, PluginApi, ApiResultItem, ApiCallError } from "src/utils/types"
+import { ArtifactMapped, AssistantMapped, DialogMapped, StoredItem, WorkspaceMapped } from "src/services/supabase/types"
+import { Ref, computed, inject } from "vue"
+import { storeToRefs } from "pinia"
+import { usePluginsStore } from "src/stores/plugins"
+import { isPlatformEnabled, mimeTypeMatch } from "src/utils/functions"
+import artifactsPlugin from 'src/utils/artifacts-plugin'
+import { useUserPerfsStore } from "src/stores/user-perfs"
+import { useUserDataStore } from "src/stores/user-data"
+import { useQuasar } from "quasar"
+import { useI18n } from "vue-i18n"
+import { useCallApi } from "src/composables/call-api"
+import { useLlmDialog } from "src/composables/llm/useLlmDialog"
+import { useGetModel } from "src/composables/get-model"
+import { jsonSchema, tool, Tool } from "ai"
+
+type CallTool = (plugin: Plugin, api: PluginApi, args: Record<string, any>) => Promise<{ result?: ApiResultItem[], error?: string }>
+
+export const useAssistantTools = (assistant: Ref<AssistantMapped>, workspace: Ref<WorkspaceMapped>, dialog: Ref<DialogMapped>) => {
+  const pluginsStore = usePluginsStore()
+  const { data: perfs } = storeToRefs(useUserPerfsStore())
+  const { data: userData } = storeToRefs(useUserDataStore())
+
+  const { getModel } = useGetModel()
+
+  const model = computed(() => getModel(dialog.value?.model_override || assistant.value?.model))
+
+  const { getSystemPrompt } = useLlmDialog(workspace, dialog)
+  const { callApi } = useCallApi(workspace, dialog)
+  const activePlugins = computed<Plugin[]>(() => assistant.value ? pluginsStore.plugins.filter(p => p.available && assistant.value.plugins[p.id]?.enabled) : [])
+  const artifacts = inject<Ref<ArtifactMapped[]>>('artifacts')
+
+  const openedArtifacts = computed(() => artifacts.value.filter(a => userData.value.openedArtifacts.includes(a.id)))
+  const $q = useQuasar()
+  const { t } = useI18n()
+  const { plugins } = assistant.value
+
+  function getCommonVars() {
+    return {
+      _currentTime: new Date().toString(),
+      _userLanguage: navigator.language,
+      _workspaceId: workspace.value.id,
+      _workspaceName: workspace.value.name,
+      _assistantId: assistant.value.id,
+      _assistantName: assistant.value.name,
+      _dialogId: dialog.value.id,
+      _modelId: model.value.name,
+      _isDarkMode: $q.dark.isActive,
+      _platform: $q.platform
+    }
+  }
+
+  function toToolResultContent(items: (ApiResultItem | StoredItem)[]) {
+    const val = []
+    for (const item of items) {
+      if (!item) continue // TODO: in case if tool failed ignore it
+      if (item.type === 'text') {
+        // Handle both ApiResultItem (contentText) and StoredItem (content_text)
+        const text = 'content_text' in item ? item.content_text : item.contentText
+        val.push({ type: 'text', text })
+      } else {
+        // Handle mime type field differences: ApiResultItem uses mimeType, StoredItem uses mime_type
+        const mimeType = 'mime_type' in item ? item.mime_type : item.mimeType
+        if (mimeTypeMatch(mimeType, model.value.inputTypes.tool)) {
+          val.push({
+            type: mimeType?.startsWith('image/') ? 'image' : 'file',
+            mimeType,
+            data: 'contentBuffer' in item ? item.contentBuffer : null
+          })
+        }
+      }
+    }
+    return val
+  }
+
+  const createTool = (description: string, plugin: Plugin, api: PluginApi, callTool: CallTool) => {
+    return tool({
+      description,
+      parameters: jsonSchema(api.parameters),
+      async execute(args) {
+        const { result, error } = await callTool(plugin, api, args)
+        if (error) throw new ApiCallError(error)
+        return result
+      },
+      experimental_toToolResultContent: toToolResultContent
+    })
+  }
+
+  const getAssistantTools = async (callTool: CallTool) => {
+    const enabledPlugins: PluginPrompt[] = []
+    const commonVars = getCommonVars()
+    const tools = {} as Record<string, Tool>
+    let noRoundtrip = true
+    await Promise.all(activePlugins.value.map(async p => {
+      noRoundtrip &&= p.noRoundtrip
+      const plugin = plugins[p.id]
+      console.log(`----plugin ${p.id}`, plugin, p.noRoundtrip)
+      const pluginVars = {
+        ...commonVars,
+        ...plugin.vars
+      }
+      plugin.tools.forEach(api => {
+        if (!api.enabled) return
+        const a = p.apis.find(a => a.name === api.name)
+        const { name, prompt } = a
+        tools[`${p.id}-${name}`] = createTool(engine.parseAndRenderSync(prompt, pluginVars), p, a, callTool)
+      })
+
+      const pluginInfos = {}
+      await Promise.all(plugin.infos.map(async api => {
+        if (!api.enabled) return
+        const a = p.apis.find(a => a.name === api.name)
+        if (a.infoType !== 'prompt-var') return
+        try {
+          pluginInfos[a.name] = await callApi(p, a, api.args)
+        } catch (e) {
+          $q.notify({ message: t('dialogView.callPluginInfoFailed', { message: e.message }), color: 'negative' })
+        }
+      }))
+
+      try {
+        enabledPlugins.push({
+          id: p.id,
+          prompt: p.prompt && engine.parseAndRenderSync(p.prompt, { ...pluginVars, infos: pluginInfos }),
+          actions: []
+        })
+      } catch (e) {
+        $q.notify({ message: t('dialogView.pluginPromptParseFailed', { title: p.title }), color: 'negative' })
+      }
+    }))
+
+    if (isPlatformEnabled(perfs.value.artifactsEnabled) && openedArtifacts.value.length > 0) {
+      const { plugin, getPrompt, api } = artifactsPlugin
+      enabledPlugins.push({
+        id: plugin.id,
+        prompt: getPrompt(openedArtifacts.value),
+        actions: []
+      })
+
+      tools[`${plugin.id}-${api.name}`] = createTool(api.prompt, plugin, api, callTool)
+    }
+
+    const systemPrompt = getSystemPrompt(enabledPlugins.filter(p => p.prompt),
+      assistant.value.prompt_template,
+      assistant.value.prompt, {
+        ...commonVars,
+        ...workspace.value.vars,
+        ...dialog.value.input_vars
+      })
+
+    return { noRoundtrip, tools, systemPrompt }
+  }
+
+  return {
+    getAssistantTools,
+    toToolResultContent
+  }
+}

--- a/src/composables/llm/useLlmDialog.ts
+++ b/src/composables/llm/useLlmDialog.ts
@@ -112,6 +112,7 @@ export const useLlmDialog = (workspace: Ref<WorkspaceMapped>, dialog: Ref<Dialog
 
   async function stream(target, insert = false, abortController: AbortController | null = null) {
     isStreaming.value = true
+
     const messageContent: AssistantMessageContent = {
       type: 'assistant-message',
       text: ''
@@ -173,7 +174,11 @@ export const useLlmDialog = (workspace: Ref<WorkspaceMapped>, dialog: Ref<Dialog
     try {
       const settings = getAssistantModelSettings(assistant.value, noRoundtrip ? { maxSteps: 1 } : {})
       const messages = getChainMessages()
-      systemPrompt && messages.unshift({ role: assistant.value.prompt_role, content: systemPrompt })
+
+      if (systemPrompt) {
+        messages.unshift({ role: assistant.value.prompt_role, content: systemPrompt })
+      }
+
       const params = {
         model: sdkModel.value,
         messages,
@@ -181,6 +186,7 @@ export const useLlmDialog = (workspace: Ref<WorkspaceMapped>, dialog: Ref<Dialog
         ...settings,
         abortSignal: abortController?.signal
       }
+
       let result: StreamTextResult<any, any> | GenerateTextResult<any, any>
       if (assistant.value.stream) {
         result = streamText(params)
@@ -221,6 +227,7 @@ export const useLlmDialog = (workspace: Ref<WorkspaceMapped>, dialog: Ref<Dialog
 
     perfs.artifactsAutoExtract && autoExtractArtifact(message, getDialogContents(-3, -1))
     isStreaming.value = false
+    perfs.autoGenTitle && chain.value.length === 4 && genTitle(getDialogContents())
   }
 
   return {

--- a/src/composables/llm/useLlmDialog.ts
+++ b/src/composables/llm/useLlmDialog.ts
@@ -111,8 +111,9 @@ export const useLlmDialog = (workspace: Ref<WorkspaceMapped>, dialog: Ref<Dialog
   // }
 
   async function stream(target, insert = false, abortController: AbortController | null = null) {
-    isStreaming.value = true
-
+    if (target) {
+      await dialogsStore.updateDialogMessage(dialog.value.id, target, { status: 'default' })
+    }
     const messageContent: AssistantMessageContent = {
       type: 'assistant-message',
       text: ''
@@ -136,6 +137,8 @@ export const useLlmDialog = (workspace: Ref<WorkspaceMapped>, dialog: Ref<Dialog
       }],
       status: 'inputing'
     })
+
+    isStreaming.value = true
 
     // const update = throttle(() => dialogsStore.updateDialogMessage(props.id, id, { message_contents: contents }), 50)
     const update = async () => await dialogsStore.updateDialogMessage(dialog.value.id, id, { message_contents: contents })

--- a/src/composables/llm/useLlmDialog.ts
+++ b/src/composables/llm/useLlmDialog.ts
@@ -1,0 +1,103 @@
+import { useDialogsStore } from "src/stores/dialogs"
+import { generateTitle, generateArtifactName, generateExtractArtifact } from "src/services/llm/utils"
+import { computed, Ref, toRef } from "vue"
+import { useUserPerfsStore } from "src/stores/user-perfs"
+import { useGetModel } from "../get-model"
+import { useI18n } from "vue-i18n"
+import { DialogMapped, DialogMessageMapped, MessageContentMapped, WorkspaceMapped } from "@/services/supabase/types"
+import { useQuasar } from "quasar"
+import { ConvertArtifactOptions, PluginPrompt } from "@/utils/types"
+import { useCreateArtifact } from "../create-artifact"
+import { ExtractArtifactResult, PluginsPrompt } from "src/utils/templates"
+import { engine } from "src/utils/template-engine"
+
+export const useLlmDialog = (workspace: Ref<WorkspaceMapped>, dialog: Ref<DialogMapped>) => {
+  const dialogsStore = useDialogsStore()
+  const { createArtifact } = useCreateArtifact(toRef(workspace.value, 'id'))
+
+  const { data: perfs } = useUserPerfsStore()
+  const { getModel, getSdkModel } = useGetModel()
+  const { t, locale } = useI18n()
+  const $q = useQuasar()
+
+  const systemSdkModel = computed(() => getSdkModel(perfs.systemProvider, perfs.systemModel))
+
+  const genTitle = async (contents: MessageContentMapped[]) => {
+    try {
+      const title = await generateTitle(systemSdkModel.value, contents, locale.value)
+      await dialogsStore.updateDialog({ id: dialog.value.id, name: title })
+      return title
+    } catch (e) {
+      console.error(e)
+      $q.notify({ message: t('dialogView.summarizeFailed'), color: 'negative' })
+    }
+  }
+
+  const genArtifactName = async (content: string, lang?: string) => {
+    const name = await generateArtifactName(systemSdkModel.value, content, lang)
+    return name
+  }
+
+  const extractArtifact = async (message: DialogMessageMapped, text: string, pattern, options: ConvertArtifactOptions) => {
+    const name = options.name || await genArtifactName(text, options.lang)
+    const id = await createArtifact({
+      name,
+      language: options.lang,
+      versions: [{
+        date: new Date().toISOString(),
+        text
+      }],
+      tmp: text
+    })
+    if (options.reserveOriginal) return
+    const to = `> ${t('dialogView.convertedToArtifact')}: <router-link to="?openArtifact=${id}">${name}</router-link>\n`
+    const index = message.message_contents.findIndex(c => ['assistant-message', 'user-message'].includes(c.type))
+
+    await dialogsStore.updateDialogMessage(dialog.value.id, message.id, {
+      message_contents: message.message_contents.map((c, i) => i === index ? {
+        ...c,
+        text: c.text.replace(pattern, to)
+      } : c)
+    })
+  }
+
+  async function autoExtractArtifact(message: DialogMessageMapped, contents: MessageContentMapped[]) {
+    const text = await generateExtractArtifact(systemSdkModel.value, contents)
+    const object: ExtractArtifactResult = JSON.parse(text)
+    if (!object.found) return
+    const reg = new RegExp(`(\`{3,}.*\\n)?(${object.regex})(\\s*\`{3,})?`)
+    const content = message.message_contents.find(c => c.type === 'assistant-message')
+    const match = content.text.match(reg)
+    if (!match) return
+    await extractArtifact(message, match[2], reg, {
+      name: object.name,
+      lang: object.language,
+      reserveOriginal: perfs.artifactsReserveOriginal
+    })
+  }
+
+  function getSystemPrompt(pluginPrompts: PluginPrompt[], promptTemplate: string, rolePrompt: string, vars: Record<string, any>) {
+    try {
+      const prompt = engine.parseAndRenderSync(promptTemplate, {
+        ...vars,
+        _pluginsPrompt: pluginPrompts.length
+          ? engine.parseAndRenderSync(PluginsPrompt, { plugins: pluginPrompts })
+          : '',
+        _rolePrompt: rolePrompt
+      })
+      return prompt.trim() ? prompt : undefined
+    } catch (e) {
+      console.error(e)
+      $q.notify({ message: t('dialogView.promptParseFailed'), color: 'negative' })
+      throw e
+    }
+  }
+
+  return {
+    genTitle,
+    genArtifactName,
+    extractArtifact,
+    autoExtractArtifact,
+    getSystemPrompt
+  }
+}

--- a/src/composables/useDialogView.ts
+++ b/src/composables/useDialogView.ts
@@ -62,7 +62,6 @@ export const useDialogView = (dialog: Ref<DialogMapped>, assistant: Ref<Assistan
   const dialogMessages = computed(() => dialogsStore.dialogMessages[dialog.value.id] || [])
   const { model } = useDialogModel(dialog, assistant)
 
-  const { toToolResultContent } = useAssistantTools(assistant, workspace, dialog)
   const storage = useStorage()
   const { chain, historyChain, updateMsgRoute, switchChain } = useDialogChain(dialog)
 
@@ -73,11 +72,6 @@ export const useDialogView = (dialog: Ref<DialogMapped>, assistant: Ref<Assistan
   const messageMap = computed<Record<string, DialogMessageMapped>>(() => {
     const map = {}
     dialogMessages.value.forEach(m => { map[m.id] = m })
-    return map
-  })
-  const itemMap = computed<Record<string, StoredItemMapped>>(() => {
-    const map = {}
-    dialogMessages.value.flatMap(m => m.message_contents).flatMap(c => c.stored_items).forEach(i => { map[i.id] = i })
     return map
   })
 
@@ -137,8 +131,10 @@ export const useDialogView = (dialog: Ref<DialogMapped>, assistant: Ref<Assistan
     ids.forEach(id => {
       delete msgTree[id]
     })
+
+    await dialogsStore.removeDialogMessages(ids)
+
     await dialogsStore.updateDialog({ id: dialog.value.id, msg_tree: msgTree })
-    // })
   }
 
   function getChainMessages() {
@@ -226,7 +222,6 @@ export const useDialogView = (dialog: Ref<DialogMapped>, assistant: Ref<Assistan
     chain,
     historyChain,
     messageMap,
-    itemMap,
     switchChain,
     updateMsgRoute,
     editBranch,

--- a/src/composables/useDialogView.ts
+++ b/src/composables/useDialogView.ts
@@ -1,0 +1,233 @@
+import { AssistantMapped, DialogMapped, DialogMessageMapped, MessageContentMapped, StoredItem, StoredItemMapped, WorkspaceMapped } from "@/services/supabase/types"
+import { useDialogsStore } from "src/stores/dialogs"
+import { genId, mimeTypeMatch } from "src/utils/functions"
+import { CoreMessage } from "ai"
+import { computed, readonly, Ref, ref, toRaw, watch } from "vue"
+import { getFileUrl } from "./storage/utils"
+import { useAssistantTools } from "./llm/useAssistantTools"
+import { UserMessageContent } from "@/common/types/dialogs"
+import { ApiResultItem } from "@/utils/types"
+import { useStorage } from "./storage/useStorage"
+import { useGetModel } from "./get-model"
+import { useUserPerfsStore } from "src/stores/user-perfs"
+
+export const useDialogModel = (dialog: Ref<DialogMapped>, assistant: Ref<AssistantMapped>) => {
+  const { getModel, getSdkModel } = useGetModel()
+  const modelOptions = ref({})
+  const { data: perfs } = useUserPerfsStore()
+
+  const model = computed(() => getModel(dialog.value?.model_override || assistant.value?.model))
+
+  const sdkModel = computed(() => getSdkModel(assistant.value?.provider, model.value, modelOptions.value))
+
+  const systemSdkModel = computed(() => getSdkModel(perfs.systemProvider, perfs.systemModel))
+
+  return { model, sdkModel, modelOptions, systemSdkModel }
+}
+
+export const useDialogChain = (dialog: Ref<DialogMapped>) => {
+  const historyChain = ref<string[]>([])
+  const dialogsStore = useDialogsStore()
+
+  const chain = computed<string[]>(() => dialog.value ? getChain(null, dialog.value.msg_route)[0] : [])
+
+  async function updateChain(route) {
+    const res = getChain(null, route)
+    historyChain.value = res[0]
+    await dialogsStore.updateDialog({ id: dialog.value.id, msg_route: res[1] })
+  }
+
+  function getChain(node, route: number[]) {
+    const children = dialog.value.msg_tree[node]
+    const r = route.at(0) || 0
+    if (children[r]) {
+      const [restChain, restRoute] = getChain(children[r], route.slice(1))
+      return [[node, ...restChain], [r, ...restRoute]]
+    } else {
+      return [[node], [r]]
+    }
+  }
+
+  async function switchChain(index: number, value: number) {
+    const route = [...dialog.value.msg_route.slice(0, index), value]
+    await updateChain(route)
+  }
+
+  return { chain, historyChain, updateChain, switchChain }
+}
+
+export const useDialogView = (dialog: Ref<DialogMapped>, assistant: Ref<AssistantMapped>, workspace: Ref<WorkspaceMapped>) => {
+  const dialogsStore = useDialogsStore()
+  const dialogMessages = computed(() => dialogsStore.dialogMessages[dialog.value.id] || [])
+  const { model } = useDialogModel(dialog, assistant)
+
+  const { toToolResultContent } = useAssistantTools(assistant, workspace, dialog)
+  const storage = useStorage()
+  const { chain, historyChain, updateChain, switchChain } = useDialogChain(dialog)
+
+  watch([() => dialogMessages.value.length, () => dialog.value?.id], () => {
+    dialog.value && updateChain(dialog.value.msg_route)
+  })
+  const messageMap = computed<Record<string, DialogMessageMapped>>(() => {
+    const map = {}
+    dialogMessages.value.forEach(m => { map[m.id] = m })
+    return map
+  })
+  const itemMap = computed<Record<string, StoredItemMapped>>(() => {
+    const map = {}
+    dialogMessages.value.flatMap(m => m.message_contents).flatMap(c => c.stored_items).forEach(i => { map[i.id] = i })
+    return map
+  })
+
+  async function updateInputText(text) {
+    await dialogsStore.updateDialogMessage(dialog.value.id, chain.value.at(-1), {
+      // use shallow keyPath to avoid dexie's sync bug
+      message_contents: [{
+        ...inputMessageContent.value,
+        text
+      }] as MessageContentMapped[],
+      status: 'inputing'
+    })
+  }
+
+  async function addInputItems(items: ApiResultItem[]) {
+    const storedItems: StoredItemMapped[] = await Promise.all(items.map(r => storage.apiResultItemToStoredItem(r, dialog.value.id)))
+
+    await dialogsStore.updateDialogMessage(dialog.value.id, chain.value.at(-1), {
+      message_contents: [{
+        ...inputMessageContent.value,
+        stored_items: [...inputMessageContent.value.stored_items, ...storedItems.filter(i => i)]
+      }]
+    })
+  }
+  const inputMessageContent = computed(() => messageMap.value[chain.value.at(-1)]?.message_contents[0] as UserMessageContent)
+  const inputContentItems = computed(() => inputMessageContent.value.stored_items.map(item => itemMap.value[item.id]).filter(x => x))
+  const inputEmpty = computed(() => !inputMessageContent.value?.text && !inputMessageContent.value?.stored_items.length)
+
+  async function editBranch(index: number) {
+    const target_index = chain.value[index - 1]
+    const { type, message_contents } = messageMap.value[chain.value[index]]
+    await switchChain(index - 1, dialog.value.msg_tree[target_index].length)
+
+    await dialogsStore.addDialogMessage(dialog.value.id, target_index, {
+      type,
+      message_contents,
+      status: 'inputing'
+    })
+  }
+
+  function expandMessageTree(root): string[] {
+    return [root, ...dialog.value.msg_tree[root].flatMap(id => expandMessageTree(id))]
+  }
+
+  async function deleteBranch(index) {
+    const parent = chain.value[index - 1]
+    const anchor = chain.value[index]
+    const branch = dialog.value.msg_route[index - 1]
+    branch === dialog.value.msg_tree[parent].length - 1 && switchChain(index - 1, branch - 1)
+    const ids = expandMessageTree(anchor)
+
+    await dialogsStore.removeDialogMessages(ids)
+
+    const msgTree = { ...toRaw(dialog.value.msg_tree) }
+    msgTree[parent] = msgTree[parent].filter(id => id !== anchor)
+    ids.forEach(id => {
+      delete msgTree[id]
+    })
+    await dialogsStore.updateDialog({ id: dialog.value.id, msg_tree: msgTree })
+    // })
+  }
+
+  function getChainMessages() {
+    const val: CoreMessage[] = []
+    historyChain.value
+      .slice(1)
+      .slice(-assistant.value.context_num || 0)
+      .filter(id => messageMap.value[id].status !== 'inputing')
+      .map(id => messageMap.value[id].message_contents)
+      .flat()
+      .forEach(content => {
+        if (content.type === 'user-message') {
+          val.push({
+            role: 'user',
+            content: [
+              { type: 'text', text: content.text },
+              ...content.stored_items.map(item => itemMap.value[item.id]).map(i => {
+                if (i.content_text != null) {
+                  if (i.type === 'file') {
+                    return { type: 'text' as const, text: `<file_content filename="${i.name}">\n${i.content_text}\n</file_content>` }
+                  } else if (i.type === 'quote') {
+                    return { type: 'text' as const, text: `<quote name="${i.name}">${i.content_text}</quote>` }
+                  } else {
+                    return { type: 'text' as const, text: i.content_text }
+                  }
+                } else {
+                  if (!mimeTypeMatch(i.mime_type, model.value.inputTypes.user)) {
+                    return null
+                  } else if (i.mime_type.startsWith('image/')) {
+                    return { type: 'image' as const, image: getFileUrl(i.file_url), mimeType: i.mime_type }
+                  } else {
+                    return { type: 'file' as const, mimeType: i.mime_type, data: getFileUrl(i.file_url) }
+                  }
+                }
+              }).filter(x => x)
+            ]
+          })
+        } else if (content.type === 'assistant-message') {
+          val.push({
+            role: 'assistant',
+            content: [
+              { type: 'text', text: content.text }
+            ]
+          })
+        } else if (content.type === 'assistant-tool') {
+          if (content.status !== 'completed') return
+          const { name, args, result, plugin_id } = content
+          const id = genId()
+          val.push({
+            role: 'assistant',
+            content: [{
+              type: 'tool-call',
+              toolName: `${plugin_id}-${name}`,
+              toolCallId: id,
+              args
+            }]
+          })
+          val.push({
+            role: 'tool',
+            content: [{
+              type: 'tool-result',
+              toolName: `${plugin_id}-${name}`,
+              toolCallId: id,
+              result: toToolResultContent(result.map(id => itemMap.value[id])),
+              experimental_content: toToolResultContent(result.map(id => itemMap.value[id]))
+            }]
+          })
+        }
+      })
+    return val
+  }
+
+  function getDialogContents(from: number = 1, to: number = -1) {
+    return chain.value.slice(from, to).map(id => messageMap.value[id].message_contents).flat()
+  }
+
+  return {
+    dialog,
+    chain,
+    historyChain,
+    messageMap,
+    itemMap,
+    switchChain,
+    updateChain,
+    editBranch,
+    deleteBranch,
+    getChainMessages,
+    updateInputText,
+    inputMessageContent,
+    inputContentItems,
+    addInputItems,
+    inputEmpty,
+    getDialogContents
+  }
+}

--- a/src/composables/workspaces/useWorkspacesWithSubscription.ts
+++ b/src/composables/workspaces/useWorkspacesWithSubscription.ts
@@ -32,7 +32,6 @@ async function fetchWorkspaces() {
   }
   workspaces.value = data.map((w) => mapWorkspaceTypes(w as Workspace))
   isLoaded.value = true
-  console.log("---fetchWorkspaces", data)
 }
 
 function subscribeToWorkspaces() {

--- a/src/layouts/TabsItem.vue
+++ b/src/layouts/TabsItem.vue
@@ -39,9 +39,10 @@ import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import DialogList from 'src/components/DialogList.vue'
 import ChatList from 'src/components/chats/ChatList.vue'
+import { useActiveWorkspace } from 'src/composables/workspaces/useActiveWorkspace'
 
-const route = useRoute()
-const workspaceId = computed(() => route.params.workspaceId as string)
+const { workspace } = useActiveWorkspace()
+const workspaceId = computed(() => workspace.value?.id as string)
 
 const tabs = ref(['chats', 'dialogs'])
 

--- a/src/services/llm/utils.ts
+++ b/src/services/llm/utils.ts
@@ -1,0 +1,34 @@
+import { engine } from "src/utils/template-engine"
+import { generateText, LanguageModelV1 } from "ai"
+import { MessageContentMapped } from "../supabase/types"
+import { GenDialogTitle, NameArtifactPrompt, ExtractArtifactPrompt } from "src/utils/templates"
+
+const generateTitle = async (model: LanguageModelV1, contents: MessageContentMapped[], lang: string) => {
+  const { text } = await generateText({
+    model,
+    prompt: await engine.parseAndRender(GenDialogTitle, {
+      contents,
+      lang
+    })
+  })
+
+  return text
+}
+
+const generateArtifactName = async (model: LanguageModelV1, content: string, lang?: string) => {
+  const { text } = await generateText({
+    model,
+    prompt: engine.parseAndRenderSync(NameArtifactPrompt, { content, lang })
+  })
+  return text
+}
+
+const generateExtractArtifact = async (model: LanguageModelV1, content: MessageContentMapped[], lang?: string) => {
+  const { text } = await generateText({
+    model,
+    prompt: engine.parseAndRenderSync(ExtractArtifactPrompt, { content, lang })
+  })
+  return text
+}
+
+export { generateTitle, generateArtifactName, generateExtractArtifact }

--- a/src/services/supabase/client.ts
+++ b/src/services/supabase/client.ts
@@ -4,9 +4,6 @@ import { Database } from './database.types'
 
 const supabaseUrl = process.env.SUPABASE_URL
 const supabaseKey = process.env.SUPABASE_KEY
-const testEmail = 'acidpictures@gmail.com'
-const testPassword = '1234567890'
-const chatId = 'c7e0948f-a00f-4835-a3d5-5297d1cd12f4'
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseKey)
 

--- a/src/services/supabase/types.ts
+++ b/src/services/supabase/types.ts
@@ -1,4 +1,4 @@
-import { ArtifactVersion, AssistantPlugins, Avatar, Model, ModelSettings, PromptVar, Provider } from '@/utils/types'
+import { ArtifactVersion, AssistantPlugins, Avatar, Model, ModelSettings, PromptVar, Provider, ToolResultContent } from '@/utils/types'
 import { Database, Json } from './database.types'
 import { LanguageModelUsage } from 'ai'
 
@@ -44,6 +44,13 @@ type ChatMapped = Database['public']['Tables']['chats']['Insert'] & {
 
 type StoredItemMapped = Omit<Database['public']['Tables']['stored_items']['Insert'], 'message_content_id' | 'dialog_id' | 'type'> & {dialog_id?: string, type: 'text' | 'file' | 'quote', message_content_id?: string}
 
+type MessageContentResult = {
+  type: StoredItemMapped['type']
+  content_text?: StoredItemMapped['content_text']
+  file_url?: StoredItemMapped['file_url']
+  mime_type?: StoredItemMapped['mime_type']
+}
+
 type WorkspaceMemberRole = 'admin' | 'member' | 'readonly'
 type WorkspaceRole = 'owner' | 'admin' | 'member' | 'readonly' | 'none'
 
@@ -74,7 +81,7 @@ type ChatMessageWithProfile = ChatMessage & {
   sender: ProfileMapped | null
 }
 
-type AssistantMapped = Omit<Assistant, 'plugins'> & {
+type AssistantMapped = Omit<Assistant, 'plugins' | 'model_settings' | 'model' | 'provider' | 'prompt_vars' | 'avatar' | 'prompt_role'> & {
   avatar: Avatar
   prompt_vars: PromptVar[]
   provider: Provider
@@ -84,10 +91,10 @@ type AssistantMapped = Omit<Assistant, 'plugins'> & {
   prompt_role: 'system' | 'user' | 'assistant'
 };
 
-type MessageContentMapped = Omit<Database['public']['Tables']['message_contents']['Insert'], 'message_id' | 'stored_items'> & {
+type MessageContentMapped = Omit<Database['public']['Tables']['message_contents']['Insert'], 'message_id' | 'stored_items' | 'result'> & {
   stored_items?: StoredItemMapped[]
   message_id?: string
-
+  result?: MessageContentResult[]
 }
 
 type DialogMessageStatus = 'pending' | 'streaming' | 'failed' | 'default' | 'inputing' | 'processed'
@@ -108,5 +115,5 @@ export type {
   MessageContent, WorkspaceMember, StoredItem, DialogMessageMapped, MessageContentMapped, DialogMapped,
   StoredItemMapped, CustomProviderMapped, SubproviderMapped, UserDataMapped,
   WorkspaceMemberRole,
-  WorkspaceMemberMapped, WorkspaceRole, ChatMapped, ProfileMapped
+  WorkspaceMemberMapped, WorkspaceRole, ChatMapped, ProfileMapped, MessageContentResult
 }

--- a/src/services/supabase/types.ts
+++ b/src/services/supabase/types.ts
@@ -74,7 +74,7 @@ type ChatMessageWithProfile = ChatMessage & {
   sender: ProfileMapped | null
 }
 
-type AssistantMapped = Assistant & {
+type AssistantMapped = Omit<Assistant, 'plugins'> & {
   avatar: Avatar
   prompt_vars: PromptVar[]
   provider: Provider

--- a/src/services/supabase/types.ts
+++ b/src/services/supabase/types.ts
@@ -42,7 +42,7 @@ type ChatMapped = Database['public']['Tables']['chats']['Insert'] & {
   type?: ChatType
 }
 
-type StoredItemMapped =Omit<Database['public']['Tables']['stored_items']['Insert'], 'message_content_id' | 'dialog_id' | 'type'> & {dialog_id?: string, type: 'text' | 'file' | 'quote', message_content_id?: string}
+type StoredItemMapped = Omit<Database['public']['Tables']['stored_items']['Insert'], 'message_content_id' | 'dialog_id' | 'type'> & {dialog_id?: string, type: 'text' | 'file' | 'quote', message_content_id?: string}
 
 type WorkspaceMemberRole = 'admin' | 'member' | 'readonly'
 type WorkspaceRole = 'owner' | 'admin' | 'member' | 'readonly' | 'none'
@@ -61,7 +61,7 @@ type ArtifactMapped = Database['public']['Tables']['artifacts']['Insert'] & {
   versions: ArtifactVersion[]
 }
 
-type DialogMapped = Dialog & {
+type DialogMapped = Omit<Dialog, 'msg_tree' | 'msg_route'> & {
   assistant: Assistant | null
   model_override: Model | null
   input_vars: Record<string, string>
@@ -84,7 +84,7 @@ type AssistantMapped = Omit<Assistant, 'plugins'> & {
   prompt_role: 'system' | 'user' | 'assistant'
 };
 
-type MessageContentMapped = Omit<Database['public']['Tables']['message_contents']['Insert'], 'message_id'> & {
+type MessageContentMapped = Omit<Database['public']['Tables']['message_contents']['Insert'], 'message_id' | 'stored_items'> & {
   stored_items?: StoredItemMapped[]
   message_id?: string
 

--- a/src/stores/dialogs.ts
+++ b/src/stores/dialogs.ts
@@ -50,12 +50,12 @@ export const useDialogsStore = defineStore('dialogs', () => {
     }
 
     dialogMessages[dialogId] = data as DialogMessageMapped[]
-    console.log(`-- fetchDialogMessages ${dialogId}`, dialogs[dialogId].msg_route, dialogs[dialogId].msg_tree, Object.values(dialogMessages[dialogId]).map(m => toRaw(m)))
-    for (const rootId of Object.keys(dialogs[dialogId].msg_tree)) {
-      const rootContents = dialogMessages[dialogId].find(m => m.id === rootId)?.message_contents[0].text || '[root]'
-      const childContents = dialogMessages[dialogId].filter(m => dialogs[dialogId].msg_tree[rootId].includes(m.id)).map(m => m.message_contents[0].text)
-      console.log(`-- fetchDialogMessages msg_tree`, rootContents, childContents)
-    }
+    // console.log(`-- fetchDialogMessages ${dialogId}`, dialogs[dialogId].msg_route, dialogs[dialogId].msg_tree, Object.values(dialogMessages[dialogId]).map(m => toRaw(m)))
+    // for (const rootId of Object.keys(dialogs[dialogId].msg_tree)) {
+    //   const rootContents = dialogMessages[dialogId].find(m => m.id === rootId)?.message_contents[0].text || '[root]'
+    //   const childContents = dialogMessages[dialogId].filter(m => dialogs[dialogId].msg_tree[rootId].includes(m.id)).map(m => m.message_contents[0].text)
+    //   console.log(`-- fetchDialogMessages msg_tree`, rootContents, childContents)
+    // }
     return dialogMessages[dialogId]
   }
 

--- a/src/stores/dialogs.ts
+++ b/src/stores/dialogs.ts
@@ -3,7 +3,7 @@ import { Dialog, DialogMapped, DialogMessageMapped, MessageContentMapped, Stored
 import { LanguageModelUsage } from 'ai'
 import { defineStore } from 'pinia'
 import { supabase } from 'src/services/supabase/client'
-import { reactive, ref } from 'vue'
+import { reactive, ref, toRaw } from 'vue'
 import merge from 'lodash/merge'
 import { useUserLoginCallback } from 'src/composables/auth/useUserLoginCallback'
 
@@ -50,7 +50,12 @@ export const useDialogsStore = defineStore('dialogs', () => {
     }
 
     dialogMessages[dialogId] = data as DialogMessageMapped[]
-
+    console.log(`-- fetchDialogMessages ${dialogId}`, dialogs[dialogId].msg_route, dialogs[dialogId].msg_tree, Object.values(dialogMessages[dialogId]).map(m => toRaw(m)))
+    for (const rootId of Object.keys(dialogs[dialogId].msg_tree)) {
+      const rootContents = dialogMessages[dialogId].find(m => m.id === rootId)?.message_contents[0].text || '[root]'
+      const childContents = dialogMessages[dialogId].filter(m => dialogs[dialogId].msg_tree[rootId].includes(m.id)).map(m => m.message_contents[0].text)
+      console.log(`-- fetchDialogMessages msg_tree`, rootContents, childContents)
+    }
     return dialogMessages[dialogId]
   }
 

--- a/src/stores/plugins.ts
+++ b/src/stores/plugins.ts
@@ -10,7 +10,7 @@ import { IsTauri } from 'src/utils/platform-api'
 import { buildGradioPlugin, buildLobePlugin, buildMcpPlugin, calculatorPlugin, docParsePlugin, dumpMcpPlugin, emotionsPlugin, fluxPlugin, gradioDefaultData, huggingToGradio, lobeDefaultData, mcpDefaultData, mermaidPlugin, timePlugin, videoTranscriptPlugin, whisperPlugin } from 'src/utils/plugins'
 import { GradioPluginManifest, HuggingPluginManifest, McpPluginDump, McpPluginManifest } from 'src/utils/types'
 import webSearchPlugin from 'src/utils/web-search-plugin'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAssistantsStore } from './assistants'
 import { useUserPluginsStore } from './user-plugins'
@@ -57,6 +57,7 @@ export const usePluginsStore = defineStore('plugins', () => {
 
   const availableKeys = computed(() => installedPlugins.value.filter(i => i.available).map(i => i.key))
   const { data, ready } = storeToRefs(useUserPluginsStore())
+
   const plugins = computed(() => [
     webSearchPlugin.plugin,
     calculatorPlugin,
@@ -77,8 +78,9 @@ export const usePluginsStore = defineStore('plugins', () => {
     })
   ])
   async function installLobePlugin(manifest: LobeChatPluginManifest) {
+    const key = `lobe-${manifest.identifier}`
     const id = await upsertPlugin({
-      key: `lobe-${manifest.identifier}`,
+      key,
       type: 'lobechat',
       available: true,
       manifest,
@@ -86,7 +88,7 @@ export const usePluginsStore = defineStore('plugins', () => {
       updated_at: new Date().toISOString(),
     })
 
-    data.value[id] = lobeDefaultData(manifest)
+    data.value[key] = lobeDefaultData(manifest)
   }
 
   async function installGradioPlugin(manifest: GradioPluginManifest) {

--- a/src/stores/user-perfs.ts
+++ b/src/stores/user-perfs.ts
@@ -109,8 +109,6 @@ const defaultPerfs: Perfs = {
   showWarnings: false
 }
 
-const USER_PERFS_KEY = 'perfs'
-
 export const useUserPerfsStore = () => {
   const store = createUserDataStore<Perfs>('user-perfs', defaultPerfs)()
 
@@ -119,74 +117,3 @@ export const useUserPerfsStore = () => {
   })
   return store
 }
-// export const useUserPerfsStore = defineStore('user-perfs', () => {
-//   const perfs = reactive<Perfs>(defaultPerfs)
-//   const ready = ref(false)
-//   const userStore = useUserStore()
-//   const lastPerfsSnapshot = ref(cloneDeep(perfs))
-
-//   const fetchPerfs = async () => {
-//     const { data, error } = await supabase.from('user_data').select('*').eq('key', USER_PERFS_KEY).single()
-//     if (error) {
-//       if (error.code === CODE_NO_RECORD_FOUND) {
-//         await addPerfs(defaultPerfs)
-//       } else {
-//         console.error(error)
-//         return
-//       }
-//     } else {
-//       Object.assign(perfs, data.value as Perfs)
-//     }
-
-//     ready.value = true
-//   }
-
-//   const init = async () => {
-//     Object.assign(perfs, defaultPerfs)
-//     await fetchPerfs()
-//   }
-
-//   useUserLoginCallback(init)
-
-//   const addPerfs = async (value:Perfs) => {
-//     const { data, error } = await supabase.from('user_data').insert({ user_id: userStore.currentUserId, key: USER_PERFS_KEY, value }).select().single()
-//     if (data) {
-//       Object.assign(perfs, data.value as Perfs)
-//     }
-//   }
-
-//   const updatePerfs = async (value: Perfs) => {
-//     const { data, error } = await supabase.from('user_data').upsert({ key: USER_PERFS_KEY, value })
-//       .eq('key', USER_PERFS_KEY).eq('user_id', userStore.currentUserId).select().single()
-
-//     if (data) {
-//       Object.assign(perfs, data.value as Perfs)
-//     }
-//     if (error) {
-//       console.error(error)
-//     }
-//   }
-
-//   const restore = () => {
-//     Object.assign(perfs, defaultPerfs)
-//     updatePerfs(perfs)
-//   }
-
-//   const throttledUpdate = throttle((perfs: Perfs) => {
-//     updatePerfs(perfs)
-//   }, 2000)
-
-//   watch(perfs, () => {
-//     if (!ready.value) return
-//     if (!isEqual(perfs, lastPerfsSnapshot.value)) {
-//       throttledUpdate(perfs)
-//       lastPerfsSnapshot.value = cloneDeep(perfs)
-//     }
-//   }, { deep: true })
-
-//   watchEffect(() => {
-//     Dark.set(perfs.darkMode)
-//   })
-
-//   return { perfs, ready, init, restore }
-// })

--- a/src/utils/assistant-utils.ts
+++ b/src/utils/assistant-utils.ts
@@ -1,0 +1,13 @@
+import { AssistantMapped } from "src/services/supabase/types"
+import { ModelSettings } from "./types"
+
+export const getAssistantModelSettings = (assistant: AssistantMapped, override: Partial<ModelSettings> = {}) => {
+  const settings: Partial<ModelSettings> = {}
+  for (const key in assistant.model_settings) {
+    const val = assistant.model_settings[key]
+    if (val || val === 0) {
+      settings[key] = val
+    }
+  }
+  return { ...settings, ...override }
+}

--- a/src/utils/dialog.ts
+++ b/src/utils/dialog.ts
@@ -1,0 +1,43 @@
+import { MessageContentResult } from "@/services/supabase/types"
+import { ToolResultContent } from "./types"
+import { getFileUrl } from "src/composables/storage/utils"
+import { pickBy } from "lodash"
+
+// TODO: multimodal version ???
+// export const storedItemResultContent = async (item: MessageContentResult, mimeSupported: string[]): Promise<ToolResultContent> => {
+//   const { type, mime_type, content_text, file_url } = item
+
+//   const result: ToolResultContent = {
+//     type: type as ToolResultContent['type'],
+//   }
+
+//   if (content_text) {
+//     result.text = content_text
+//   }
+
+//   if (file_url) {
+//     const url = getFileUrl(file_url)
+//     if (mimeSupported.includes(mime_type)) {
+//       result.mimeType = mime_type
+
+//       result.data = await fetch(url).then(res => res.arrayBuffer())
+//     } else {
+//       result.text = url
+//     }
+//   }
+
+//   return result
+// }
+
+export const storedItemResultContent = (item: MessageContentResult) => {
+  const { type, mime_type, content_text, file_url } = item
+
+  const result: ToolResultContent = {
+    type: type as ToolResultContent['type'],
+    mimeType: mime_type,
+    data: file_url ? getFileUrl(file_url) : undefined,
+    text: content_text
+  }
+
+  return pickBy(result, (v) => v !== undefined) as ToolResultContent
+}

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -99,37 +99,37 @@ const DefaultWsIndexContent = t('templates.defaultWsIndexContent')
 
 const ExtractArtifactSchema = Object({
   thinking: String({
-    description: '在你判断助手回答中是否有适合提取为 Artifact 的独立内容的过程中，你思考的过程。'
+    description: 'During the process of determining whether there are artifacts in the conversation record between the user and the AI assistant, your thinking process.'
   }),
   found: Boolean({
-    description: '是否有适合提取为 Artifact 的独立内容'
+    description: 'Whether there are artifacts in the conversation record between the user and the AI assistant'
   }),
   regex: Optional(String({
-    description: '用于提取 Artifacts 的 JS 正则表达式字符串，需恰好匹配整个 Artifact。Artifacts 很长，可用 `[\\s\\S]*` 匹配中间任意内容。如果 Artifact 代码块，请**不要**包含开头的 "\`\`\`" 标记。'
+    description: 'A JS regular expression string for extracting artifacts, which must exactly match the entire artifact. Artifacts are long, and `[\\s\\S]*` can be used to match any content in the middle. If the artifact is a code block, please **do not** include the opening "\`\`\`" marker.'
   })),
   name: Optional(String({
-    description: '根据 Artifact 内容为 Artifact 命名。像文件名那样带后缀。命名格式需符合对应语言代码的文件命名规范。'
+    description: 'Name the artifact according to its content. Like a file name with a suffix. The naming format must conform to the file naming conventions of the corresponding language code.'
   })),
   language: Optional(String({
-    description: '内容的代码语言，用于代码高亮。示例值："markdown", "javascript", "python" 等'
+    description: 'The code language of the content, used for code highlighting. Example values: "markdown", "javascript", "python", etc.'
   }))
 })
 type ExtractArtifactResult = Static<typeof ExtractArtifactSchema>
 const ExtractArtifactPrompt =
 `
 <instruction>
-你的任务是判断用户与 AI 助手对话记录中是否有 Artifacts，如果有则将它提取出来。
+Your task is to determine whether there are artifacts in the conversation record between the user and the AI assistant, and if so, extract them.
 
-Artifacts 可以是一长段完整的代码、一篇完整的文章、报告。用户可能会复用、修改这些内容，且内容较长（>15行），因此将它们提取出来。
+Artifacts can be a long complete code, a complete article, or a report. Users may reuse and modify these contents, and the content is long (>15 lines), so they are extracted.
 
-对于其他内容（一般的问题解答、操作步骤等）则不提取，认为未找到 Artifact。
+Other content (general question answers, operation steps, etc.) will not be extracted, and it is considered that no artifacts are found.
 
-如果没有适合提取为 Artifact 的独立内容，返回 \`found\` 为 false 即可；
-如果有，请确定 Artifact 在 assistant message 中的范围，给出用于提取 Artifact 的正则表达式，以及 Artifact 的语言和命名。
+If there is no independent content suitable for extraction as an artifact, return \`found\` as false;
+If there is, please determine the scope of the artifact in the assistant message, give the regular expression for extracting the artifact, and the language and name of the artifact.
 
-如果 Artifact 是代码块，则它必须是完整的代码块，不能是代码块的一部分或者多个短代码块。不合适的情况认为没有找到 Artifact 即可。
+If the artifact is a code block, it must be a complete code block, not a part of a code block or multiple short code blocks. In the case of inappropriate situations, it is considered that the artifact is not found.
 
-回复为 json 格式，只回答 json 内容，不要用 "\`\`\`" 包裹。
+The reply is in json format, only the json content is answered, and it is not wrapped in "\`\`\`".
 </instruction>
 <response_schema>
 ${JSON.stringify(ExtractArtifactSchema, null, 2)}
@@ -150,11 +150,11 @@ ${JSON.stringify(ExtractArtifactSchema, null, 2)}
 `
 const NameArtifactPrompt =
 `<instruction>
-请根据该文件的内容，为该文件命名。要求：
-- 文件名带后缀
-- 文件名符合对应语言代码的文件命名规范，如 "hello_world.py"（下划线格式）, "hello-world.js"（连字符格式）, "HelloWorld.java"（驼峰格式） 等。
-- 长度不超过 3 个单词
-- 只回答文件名，不要回答任何其他内容。
+Please name the file according to its content. Requirements:
+- The file name must have a suffix
+- The file name must conform to the file naming conventions of the corresponding language code, such as "hello_world.py" (underscore format), "hello-world.js" (hyphen format), "HelloWorld.java" (camel case format), etc.
+- The length must not exceed 3 words
+- Only answer the file name, do not answer anything else.
 </instruction>
 <file_content {%- if lang %} lang="{{ lang }}"{%- endif %}>
 {{ content }}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -81,6 +81,13 @@ interface ApiResultItem {
   mimeType?: string
 }
 
+interface ToolResultContent {
+  type: 'text' | 'file' | 'image'
+  text?: string
+  data?: string | ArrayBuffer | null
+  mimeType?: string
+}
+
 class ApiCallError extends Error {}
 
 interface AssistantPluginInfo {
@@ -460,5 +467,6 @@ export type {
   McpPluginManifest,
   TransportConf,
   ArtifactVersion,
-  PluginPrompt
+  PluginPrompt,
+  ToolResultContent
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -156,6 +156,12 @@ interface Plugin {
   homepage?: string
 }
 
+interface PluginPrompt {
+  id: string
+  prompt: string
+  actions?: string[]
+}
+
 interface InstalledLobePlugin {
   id: string
   key: string
@@ -453,5 +459,6 @@ export type {
   McpPluginDump,
   McpPluginManifest,
   TransportConf,
-  ArtifactVersion
+  ArtifactVersion,
+  PluginPrompt
 }

--- a/src/views/DialogView.vue
+++ b/src/views/DialogView.vue
@@ -207,18 +207,18 @@
           <message-image
             v-for="image in inputContentItems.filter(i => i.mime_type?.startsWith('image/'))"
             :key="image.id"
-            :image="image as StoredItemMapped"
+            :image="image"
             removable
             h="100px"
-            @remove="removeItem(image as StoredItemMapped)"
+            @remove="removeItem(image)"
             shadow
           />
           <message-file
             v-for="file in inputContentItems.filter(i => !i.mime_type?.startsWith('image/'))"
             :key="file.id"
-            :file
+            :file="file"
             removable
-            @remove="removeItem(file as StoredItemMapped)"
+            @remove="removeItem(file)"
             shadow
           />
         </div>
@@ -379,7 +379,7 @@
             :label="$t('dialogView.send')"
             @click="send"
             @abort="abortController?.abort()"
-            :loading="!!messageMap[chain.at(-2)]?.generating_session"
+            :loading="isStreaming || !!messageMap[chain.at(-2)]?.generating_session"
             ml-4
             min-h="40px"
           />
@@ -426,19 +426,15 @@
 <script setup lang="ts">
 import { computed, inject, onUnmounted, provide, ref, Ref, toRaw, toRef, watch, nextTick, onMounted } from 'vue'
 import { almostEqual, displayLength, genId, isPlatformEnabled, isTextFile, JSONEqual, mimeTypeMatch, pageFhStyle, textBeginning, wrapCode, wrapQuote } from 'src/utils/functions'
-import { streamText, CoreMessage, generateText, StreamTextResult, GenerateTextResult } from 'ai'
 import { useQuasar } from 'quasar'
 import { DialogContent } from 'src/utils/templates'
-import sessions from 'src/utils/sessions'
 import PromptVarInput from 'src/components/PromptVarInput.vue'
 import { PluginApi, Plugin, ModelSettings, ApiResultItem } from 'src/utils/types'
-import { UserMessageContent, AssistantMessageContent } from '@/common/types/dialogs'
 import { usePluginsStore } from 'src/stores/plugins'
 import MessageItem from 'src/components/MessageItem.vue'
 import { scaleBlob } from 'src/utils/image-process'
 import MessageImage from 'src/components/MessageImage.vue'
 import { engine } from 'src/utils/template-engine'
-import { useCallApi } from 'src/composables/call-api'
 import { until } from '@vueuse/core'
 import ViewCommonHeader from 'src/components/ViewCommonHeader.vue'
 import { useUserPerfsStore } from 'src/stores/user-perfs'
@@ -460,15 +456,13 @@ import { useI18n } from 'vue-i18n'
 import Mark from 'mark.js'
 import { useCreateDialog } from 'src/composables/create-dialog'
 import EnablePluginsMenu from 'src/components/EnablePluginsMenu.vue'
-import { useGetModel } from 'src/composables/get-model'
 import { useUiStateStore } from 'src/stores/ui-state'
 import { useDialogsStore } from 'src/stores/dialogs'
-import { Workspace, DialogMessageMapped, StoredItem, MessageContentMapped, StoredItemMapped, ArtifactMapped, WorkspaceMapped } from '@/services/supabase/types'
-import { useStorage } from 'src/composables/storage/useStorage'
-import { FILES_BUCKET, getFileUrl } from 'src/composables/storage/utils'
+import { StoredItemMapped } from '@/services/supabase/types'
 import { useActiveWorkspace } from 'src/composables/workspaces/useActiveWorkspace'
 import { useLlmDialog } from 'src/composables/llm/useLlmDialog'
 import { useAssistantTools } from 'src/composables/llm/useAssistantTools'
+import { useDialogChain, useDialogModel, useDialogView } from 'src/composables/useDialogView'
 const { t, locale } = useI18n()
 
 const props = defineProps<{
@@ -477,135 +471,79 @@ const props = defineProps<{
 
 const rightDrawerAbove = inject('rightDrawerAbove')
 
-const dialogsStore = useDialogsStore()
 const { assistant, workspace } = useActiveWorkspace()
-
-const dialogs = computed(() => Object.values(dialogsStore.dialogs))
+const dialogsStore = useDialogsStore()
 
 const dialog = computed(() => dialogsStore.dialogs[props.id])
-const dialogMessages = computed(() => dialogsStore.dialogMessages[props.id] || [])
-const { getAssistantTools, toToolResultContent } = useAssistantTools(assistant, workspace, dialog)
-watch(dialog, () => {
-  dialogsStore.fetchDialogMessages(props.id)
-})
+const { switchChain, updateChain } = useDialogChain(dialog)
+const {
+  chain, messageMap, itemMap,
+  editBranch, deleteBranch, updateInputText,
+  inputMessageContent, inputContentItems, addInputItems, inputEmpty, getDialogContents
+} = useDialogView(dialog, assistant, workspace)
+console.log('-- dialog', dialog.value, chain.value, messageMap.value, itemMap.value)
+const pluginsStore = usePluginsStore()
 
-onMounted(() => {
-  // dialogsStore.fetchDialogs()
+// const { callApi } = useCallApi(workspace, dialog)
+
+const { model, sdkModel, modelOptions } = useDialogModel(dialog, assistant)
+
+const $q = useQuasar()
+const { genTitle, extractArtifact, stream, isStreaming } = useLlmDialog(workspace, dialog, assistant)
+
+const { createDialog } = useCreateDialog(workspace.value.id)
+
+const preventLockingBottom = ref(false)
+const lockingBottom = computed(() => !preventLockingBottom.value && isStreaming.value && perfs.streamingLockBottom)
+
+// stream abort controller
+const abortController = ref<AbortController | null>(null)
+
+const startStream = async (target: string, insert = false) => {
+  preventLockingBottom.value = false
+  abortController.value = new AbortController()
+  await stream(target, insert, abortController.value)
+}
+
+watch(() => props.id, () => {
   dialogsStore.fetchDialogMessages(props.id)
-})
+}, { immediate: true })
 
 provide('dialog', dialog)
-
-const chain = computed<string[]>(() => dialog.value ? getChain(null, dialog.value.msg_route)[0] : [])
-
-const historyChain = ref<string[]>([])
-function switchChain(index: number, value: number) {
-  const route = [...dialog.value.msg_route.slice(0, index), value]
-  updateChain(route)
-}
-function updateChain(route) {
-  const res = getChain(null, route)
-  historyChain.value = res[0]
-  dialogsStore.updateDialog({ id: dialog.value.id, msg_route: res[1] })
-}
-watch([() => dialogMessages.value.length, () => dialog.value?.id], () => {
-  dialog.value && updateChain(dialog.value.msg_route)
-})
-function getChain(node, route: number[]) {
-  const children = dialog.value.msg_tree[node]
-  const r = route.at(0) || 0
-  if (children[r]) {
-    const [restChain, restRoute] = getChain(children[r], route.slice(1))
-    return [[node, ...restChain], [r, ...restRoute]]
-  } else {
-    return [[node], [r]]
-  }
-}
+provide('messageMap', messageMap)
+provide('itemMap', itemMap)
 
 const messageInput = ref()
+
 function focusInput() {
   isPlatformEnabled(perfs.autoFocusDialogInput) && messageInput.value?.focus()
 }
 async function edit(index: number) {
-  const target = chain.value[index - 1]
-  const { type, message_contents } = messageMap.value[chain.value[index]]
-  switchChain(index - 1, dialog.value.msg_tree[target].length)
-
-  await dialogsStore.addDialogMessage(props.id, target, {
-    type,
-    message_contents,
-    status: 'inputing'
-  })
+  await editBranch(index)
   await nextTick()
   focusInput()
 }
 
-async function regenerate(index) {
+function ensureAssistantAndModel() {
   if (!assistant.value) {
     $q.notify({ message: t('dialogView.errors.setAssistant'), color: 'negative' })
-    return
+    return false
   }
   if (!sdkModel.value) {
     $q.notify({ message: t('dialogView.errors.configModel'), color: 'negative' })
-    return
+    return false
   }
+
+  return true
+}
+
+async function regenerate(index) {
+  if (!ensureAssistantAndModel()) return
+
   const target = chain.value[index - 1]
   switchChain(index - 1, dialog.value.msg_tree[target].length)
-  await stream(target, false)
+  await startStream(target, false)
 }
-async function deleteBranch(index) {
-  const parent = chain.value[index - 1]
-  const anchor = chain.value[index]
-  const branch = dialog.value.msg_route[index - 1]
-  branch === dialog.value.msg_tree[parent].length - 1 && switchChain(index - 1, branch - 1)
-  const ids = expandMessageTree(anchor)
-  const itemIds = ids.flatMap(id => messageMap.value[id].message_contents).flatMap(c => {
-    if (c.type === 'user-message') return c.stored_items
-    else if (c.type === 'assistant-tool') return c.result || []
-    else return []
-  })
-
-  await dialogsStore.removeDialogMessages(ids)
-
-  const msgTree = { ...toRaw(dialog.value.msg_tree) }
-  msgTree[parent] = msgTree[parent].filter(id => id !== anchor)
-  ids.forEach(id => {
-    delete msgTree[id]
-  })
-  dialogsStore.updateDialog({ id: props.id, msg_tree: msgTree })
-  // })
-}
-
-function expandMessageTree(root): string[] {
-  return [root, ...dialog.value.msg_tree[root].flatMap(id => expandMessageTree(id))]
-}
-
-async function updateInputText(text) {
-  await dialogsStore.updateDialogMessage(props.id, chain.value.at(-1), {
-    // use shallow keyPath to avoid dexie's sync bug
-    message_contents: [{
-      ...inputMessageContent.value,
-      text
-    }] as MessageContentMapped[],
-    status: 'inputing'
-  })
-}
-const inputMessageContent = computed(() => messageMap.value[chain.value.at(-1)]?.message_contents[0] as UserMessageContent)
-const inputContentItems = computed(() => inputMessageContent.value.stored_items.map(item => itemMap.value[item.id]).filter(x => x))
-const messageMap = computed<Record<string, DialogMessageMapped>>(() => {
-  const map = {}
-  dialogMessages.value.forEach(m => { map[m.id] = m })
-  return map
-})
-const itemMap = computed<Record<string, StoredItem>>(() => {
-  const map = {}
-  dialogMessages.value.flatMap(m => m.message_contents).flatMap(c => c.stored_items).forEach(i => { map[i.id] = i })
-  return map
-})
-
-provide('messageMap', messageMap)
-provide('itemMap', itemMap)
-const inputEmpty = computed(() => !inputMessageContent.value?.text && !inputMessageContent.value?.stored_items.length)
 
 function onTextPaste(ev: ClipboardEvent) {
   if (!perfs.codePasteOptimize) return
@@ -627,7 +565,6 @@ function onTextPaste(ev: ClipboardEvent) {
 
 const imageInput = ref()
 const fileInput = ref()
-const storage = useStorage(FILES_BUCKET)
 function onInputFiles({ target }) {
   const files = target.files
   parseFiles(Array.from(files))
@@ -689,7 +626,8 @@ async function parseFiles(files: File[]) {
       contentBuffer: await f.arrayBuffer() // TODO: fix this
     })
   }
-  addInputItems(parsedFiles)
+
+  await addInputItems(parsedFiles)
 
   otherFiles.length && $q.dialog({
     component: ParseFilesDialog,
@@ -698,170 +636,39 @@ async function parseFiles(files: File[]) {
     addInputItems(files)
   })
 }
-function quote(item: ApiResultItem) {
+async function quote(item: ApiResultItem) {
   if (displayLength(item.contentText) > 200) {
-    addInputItems([item])
+    await addInputItems([item])
   } else {
     const { text } = inputMessageContent.value
     const content = wrapQuote(item.contentText) + '\n\n'
-    updateInputText(text ? text + '\n' + content : content)
+    await updateInputText(text ? text + '\n' + content : content)
     focusInput()
   }
 }
-async function addInputItems(items: ApiResultItem[]) {
-  const storedItems: StoredItemMapped[] = await Promise.all(items.map(r => storage.apiResultItemToStoredItem(r, props.id)))
 
-  await dialogsStore.updateDialogMessage(props.id, chain.value.at(-1), {
-    message_contents: [{
-      ...inputMessageContent.value,
-      stored_items: [...inputMessageContent.value.stored_items, ...storedItems.filter(i => i)]
-    }]
-  })
-}
-
-function getChainMessages() {
-  const val: CoreMessage[] = []
-  historyChain.value
-    .slice(1)
-    .slice(-assistant.value.context_num || 0)
-    .filter(id => messageMap.value[id].status !== 'inputing')
-    .map(id => messageMap.value[id].message_contents)
-    .flat()
-    .forEach(content => {
-      if (content.type === 'user-message') {
-        val.push({
-          role: 'user',
-          content: [
-            { type: 'text', text: content.text },
-            ...content.stored_items.map(item => itemMap.value[item.id]).map(i => {
-              if (i.content_text != null) {
-                if (i.type === 'file') {
-                  return { type: 'text' as const, text: `<file_content filename="${i.name}">\n${i.content_text}\n</file_content>` }
-                } else if (i.type === 'quote') {
-                  return { type: 'text' as const, text: `<quote name="${i.name}">${i.content_text}</quote>` }
-                } else {
-                  return { type: 'text' as const, text: i.content_text }
-                }
-              } else {
-                if (!mimeTypeMatch(i.mime_type, model.value.inputTypes.user)) {
-                  return null
-                } else if (i.mime_type.startsWith('image/')) {
-                  return { type: 'image' as const, image: getFileUrl(i.file_url), mimeType: i.mime_type }
-                } else {
-                  return { type: 'file' as const, mimeType: i.mime_type, data: getFileUrl(i.file_url) }
-                }
-              }
-            }).filter(x => x)
-          ]
-        })
-      } else if (content.type === 'assistant-message') {
-        val.push({
-          role: 'assistant',
-          content: [
-            { type: 'text', text: content.text }
-          ]
-        })
-      } else if (content.type === 'assistant-tool') {
-        if (content.status !== 'completed') return
-        const { name, args, result, plugin_id } = content
-        const id = genId()
-        val.push({
-          role: 'assistant',
-          content: [{
-            type: 'tool-call',
-            toolName: `${plugin_id}-${name}`,
-            toolCallId: id,
-            args
-          }]
-        })
-        val.push({
-          role: 'tool',
-          content: [{
-            type: 'tool-result',
-            toolName: `${plugin_id}-${name}`,
-            toolCallId: id,
-            result: toToolResultContent(result.map(id => itemMap.value[id])),
-            experimental_content: toToolResultContent(result.map(id => itemMap.value[id]))
-          }]
-        })
-      }
-    })
-  return val
-}
-
-// function getSystemPrompt(enabledPlugins) {
-//   try {
-//     const prompt = engine.parseAndRenderSync(assistant.value.prompt_template, {
-//       ...getCommonVars(),
-//       ...workspace.value.vars,
-//       ...dialog.value.input_vars,
-//       _pluginsPrompt: enabledPlugins.length
-//         ? engine.parseAndRenderSync(PluginsPrompt, { plugins: enabledPlugins })
-//         : '',
-//       _rolePrompt: assistant.value.prompt
-//     })
-//     return prompt.trim() ? prompt : undefined
-//   } catch (e) {
-//     console.error(e)
-//     $q.notify({ message: t('dialogView.promptParseFailed'), color: 'negative' })
-//     throw e
-//   }
-// }
-
-// function getCommonVars() {
-//   return {
-//     _currentTime: new Date().toString(),
-//     _userLanguage: navigator.language,
-//     _workspaceId: workspace.value.id,
-//     _workspaceName: workspace.value.name,
-//     _assistantId: assistant.value.id,
-//     _assistantName: assistant.value.name,
-//     _dialogId: dialog.value.id,
-//     _modelId: model.value.name,
-//     _isDarkMode: $q.dark.isActive,
-//     _platform: $q.platform
-//   }
-// }
-
-const pluginsStore = usePluginsStore()
-
-const { callApi } = useCallApi(workspace, dialog)
-
-const modelOptions = ref({})
-const { getModel, getSdkModel } = useGetModel()
-const model = computed(() => getModel(dialog.value?.model_override || assistant.value?.model))
-const sdkModel = computed(() => getSdkModel(assistant.value?.provider, model.value, modelOptions.value))
-const $q = useQuasar()
-const { genTitle, getSystemPrompt, extractArtifact, autoExtractArtifact } = useLlmDialog(workspace, dialog)
-
-const { data } = useUserDataStore()
-const openedArtifacts = computed(() => artifacts.value.filter(a => userDataStore.data.openedArtifacts.includes(a.id)))
 async function send() {
-  if (!assistant.value) {
-    $q.notify({ message: t('dialogView.errors.setAssistant'), color: 'negative' })
-    return
-  }
-  if (!sdkModel.value) {
-    $q.notify({ message: t('dialogView.errors.configModel'), color: 'negative' })
-    return
-  }
-  if (!data.noobAlertDismissed && chain.value.length > 10 && dialogs.value.length < 3) {
-    $q.dialog({
-      title: t('dialogView.noobAlert.title'),
-      message: t('dialogView.noobAlert.message'),
-      persistent: true,
-      ok: t('dialogView.noobAlert.okBtn'),
-      cancel: t('dialogView.noobAlert.cancelBtn'),
-      ...dialogOptions
-    }).onCancel(() => {
-      data.noobAlertDismissed = true
-      send()
-    })
-    return
-  }
+  if (!ensureAssistantAndModel()) return
+
+  // TODO: Noob alert - probably not needed
+  // if (!data.noobAlertDismissed && chain.value.length > 10 && dialogs.value.length < 3) {
+  //   $q.dialog({
+  //     title: t('dialogView.noobAlert.title'),
+  //     message: t('dialogView.noobAlert.message'),
+  //     persistent: true,
+  //     ok: t('dialogView.noobAlert.okBtn'),
+  //     cancel: t('dialogView.noobAlert.cancelBtn'),
+  //     ...dialogOptions
+  //   }).onCancel(() => {
+  //     data.noobAlertDismissed = true
+  //     send()
+  //   })
+  //   return
+  // }
+
   showVars.value = false
   if (inputEmpty.value) {
-    await stream(chain.value.at(-2), true)
+    await startStream(chain.value.at(-2), true)
   } else {
     const target = chain.value.at(-1)
     await dialogsStore.updateDialogMessage(props.id, target, { status: 'default' })
@@ -870,250 +677,24 @@ async function send() {
         scroll('bottom')
       })
     })
-    await stream(target, false)
+    await startStream(target, false)
   }
   perfs.autoGenTitle && chain.value.length === 4 && genTitle(getDialogContents())
 }
 
-const artifacts = inject<Ref<ArtifactMapped[]>>('artifacts')
-const abortController = ref<AbortController>()
-async function stream(target, insert = false) {
-  const settings: Partial<ModelSettings> = {}
-  for (const key in assistant.value.model_settings) {
-    const val = assistant.value.model_settings[key]
-    if (val || val === 0) {
-      settings[key] = val
-    }
-  }
-  const messageContent: AssistantMessageContent = {
-    type: 'assistant-message',
-    text: ''
-  }
-  const contents: MessageContentMapped[] = [messageContent]
-
-  const { id } = await dialogsStore.addDialogMessage(props.id, target, {
-    type: 'assistant',
-    assistant_id: assistant.value.id,
-    message_contents: contents,
-    status: 'pending',
-    generating_session: sessions.id,
-    model_name: model.value.name
-  }, insert)
-  !insert && await dialogsStore.addDialogMessage(props.id, id, {
-    type: 'user',
-    message_contents: [{
-      type: 'user-message',
-      text: '',
-      stored_items: []
-    }],
-    status: 'inputing'
-  })
-
-  // const update = throttle(() => dialogsStore.updateDialogMessage(props.id, id, { message_contents: contents }), 50)
-  const update = async () => await dialogsStore.updateDialogMessage(props.id, id, { message_contents: contents })
-
-  async function callTool(plugin: Plugin, api: PluginApi, args) {
-    const content: MessageContentMapped = {
-      type: 'assistant-tool',
-      plugin_id: plugin.id,
-      name: api.name,
-      args,
-      status: 'calling'
-    }
-
-    contents.push(content)
-
-    await update()
-
-    const { result: apiResult, error } = await callApi(plugin, api, args)
-    const result: StoredItemMapped[] = await Promise.all(apiResult.map(r => storage.apiResultItemToStoredItem(r, props.id)))
-    // saveItems(result)
-    content.stored_items = result.filter(i => i)
-    if (error) {
-      content.status = 'failed'
-      content.error = error
-    } else {
-      content.status = 'completed'
-      content.result = result.map(i => i)
-    }
-    await update()
-
-    return { result, error }
-  }
-
-  // const getEnabledPlugins = async (plugins: AssistantPlugins) => {
-  //   const tools = {}
-  //   const enabledPlugins: PluginPrompt[] = []
-  //   let noRoundtrip = true
-  //   await Promise.all(activePlugins.value.map(async p => {
-  //     noRoundtrip &&= p.noRoundtrip
-  //     const plugin = plugins[p.id]
-  //     console.log(`----plugin ${p.id}`, plugin)
-  //     const pluginVars = {
-  //       ...getCommonVars(),
-  //       ...plugin.vars
-  //     }
-  //     plugin.tools.forEach(api => {
-  //       if (!api.enabled) return
-  //       const a = p.apis.find(a => a.name === api.name)
-  //       const { name, prompt } = a
-  //       tools[`${p.id}-${name}`] = tool({
-  //         description: engine.parseAndRenderSync(prompt, pluginVars),
-  //         parameters: jsonSchema(a.parameters),
-  //         async execute(args) {
-  //           const { result, error } = await callTool(p, a, args)
-  //           if (error) throw new ApiCallError(error)
-  //           return result
-  //         },
-  //         experimental_toToolResultContent: toToolResultContent
-  //       })
-  //     })
-  //     const pluginInfos = {}
-  //     await Promise.all(plugin.infos.map(async api => {
-  //       if (!api.enabled) return
-  //       const a = p.apis.find(a => a.name === api.name)
-  //       if (a.infoType !== 'prompt-var') return
-  //       try {
-  //         pluginInfos[a.name] = await callApi(p, a, api.args)
-  //       } catch (e) {
-  //         $q.notify({ message: t('dialogView.callPluginInfoFailed', { message: e.message }), color: 'negative' })
-  //       }
-  //     }))
-
-  //     try {
-  //       enabledPlugins.push({
-  //         id: p.id,
-  //         prompt: p.prompt && engine.parseAndRenderSync(p.prompt, { ...pluginVars, infos: pluginInfos }),
-  //         actions: []
-  //       })
-  //     } catch (e) {
-  //       $q.notify({ message: t('dialogView.pluginPromptParseFailed', { title: p.title }), color: 'negative' })
-  //     }
-  //   }))
-
-  //   if (isPlatformEnabled(perfs.artifactsEnabled) && openedArtifacts.value.length > 0) {
-  //     const { plugin, getPrompt, api } = artifactsPlugin
-  //     enabledPlugins.push({
-  //       id: plugin.id,
-  //       prompt: getPrompt(openedArtifacts.value),
-  //       actions: []
-  //     })
-  //     tools[`${plugin.id}-${api.name}`] = tool({
-  //       description: api.prompt,
-  //       parameters: jsonSchema(api.parameters),
-  //       async execute(args) {
-  //         const { result, error } = await callTool(plugin, api, args)
-  //         if (error) throw new ApiCallError(error)
-  //         return result
-  //       },
-  //       experimental_toToolResultContent: toToolResultContent
-  //     })
-  //   }
-
-  //   return { noRoundtrip, tools, enabledPlugins }
-  // }
-
-  // const { noRoundtrip, tools, enabledPlugins } = await getEnabledPlugins(assistantPlugins)
-
-  // const prompt = getSystemPrompt(enabledPlugins.filter(p => p.prompt),
-  //   assistant.value.prompt_template,
-  //   assistant.value.prompt, {
-  //     ...getCommonVars(),
-  //     ...workspace.value.vars,
-  //     ...dialog.value.input_vars
-  //   })
-
-  const { noRoundtrip, tools, systemPrompt } = await getAssistantTools(callTool)
-
-  console.log(`----noRoundtrip ${noRoundtrip}`, tools, systemPrompt)
-  try {
-    if (noRoundtrip) settings.maxSteps = 1
-    abortController.value = new AbortController()
-    const messages = getChainMessages()
-    prompt && messages.unshift({ role: assistant.value.prompt_role, content: systemPrompt })
-    const params = {
-      model: sdkModel.value,
-      messages,
-      tools,
-      ...settings,
-      abortSignal: abortController.value.signal
-    }
-    let result: StreamTextResult<any, any> | GenerateTextResult<any, any>
-    if (assistant.value.stream) {
-      result = streamText(params)
-      await dialogsStore.updateDialogMessage(props.id, id, { status: 'streaming' })
-      lockingBottom.value = perfs.streamingLockBottom
-      for await (const part of result.fullStream) {
-        if (part.type === 'text-delta') {
-          messageContent.text += part.textDelta
-          await update()
-        } else if (part.type === 'reasoning') {
-          messageContent.reasoning = (messageContent.reasoning ?? '') + part.textDelta
-          await update()
-        } else if (part.type === 'error') {
-          throw part.error
-        }
-      }
-    } else {
-      result = await generateText(params)
-      messageContent.text = await result.text
-      messageContent.reasoning = await result.reasoning
-    }
-
-    const usage = await result.usage
-    const warnings = (await result.warnings).map(w => (w.type === 'unsupported-setting' || w.type === 'unsupported-tool') ? w.details : w.message)
-    await dialogsStore.updateDialogMessage(props.id, id, { message_contents: contents, status: 'default', generating_session: null, warnings, usage })
-  } catch (e) {
-    console.error(e)
-    if (e.data?.error?.type === 'budget_exceeded') {
-      $q.notify({
-        message: t('dialogView.errors.insufficientQuota'),
-        color: 'err-c',
-        textColor: 'on-err-c',
-        actions: [{ label: t('dialogView.recharge'), color: 'on-sur', handler() { router.push('/account') } }]
-      })
-    }
-    await dialogsStore.updateDialogMessage(props.id, id, { message_contents: contents, error: e.message || e.toString(), status: 'failed', generating_session: null })
-  }
-  const message = messageMap.value[chain.value.at(-2)]
-
-  perfs.artifactsAutoExtract && autoExtractArtifact(message, getDialogContents(-3, -1))
-  lockingBottom.value = false
-}
-// function toToolResultContent(items: (ApiResultItem | StoredItem)[]) {
-//   const val = []
-//   for (const item of items) {
-//     if (!item) continue // TODO: in case if tool failed ignore it
-//     if (item.type === 'text') {
-//       // Handle both ApiResultItem (contentText) and StoredItem (content_text)
-//       const text = 'content_text' in item ? item.content_text : item.contentText
-//       val.push({ type: 'text', text })
-//     } else {
-//       // Handle mime type field differences: ApiResultItem uses mimeType, StoredItem uses mime_type
-//       const mimeType = 'mime_type' in item ? item.mime_type : item.mimeType
-//       if (mimeTypeMatch(mimeType, model.value.inputTypes.tool)) {
-//         val.push({
-//           type: mimeType?.startsWith('image/') ? 'image' : 'file',
-//           mimeType,
-//           data: 'contentBuffer' in item ? item.contentBuffer : null
-//         })
-//       }
-//     }
-//   }
-//   return val
-// }
-const lockingBottom = ref(false)
 let lastScrollTop
 function scrollListener() {
   const container = scrollContainer.value
   if (container.scrollTop < lastScrollTop) {
-    lockingBottom.value = false
+    preventLockingBottom.value = true
   }
   lastScrollTop = container.scrollTop
 }
+
 function lockBottom() {
   lockingBottom.value && scroll('bottom', 'auto')
 }
+
 watch(lockingBottom, val => {
   if (val) {
     lastScrollTop = scrollContainer.value.scrollTop
@@ -1126,28 +707,6 @@ watch(lockingBottom, val => {
 const activePlugins = computed<Plugin[]>(() => assistant.value ? pluginsStore.plugins.filter(p => p.available && assistant.value.plugins[p.id]?.enabled) : [])
 const usage = computed(() => messageMap.value[chain.value.at(-2)]?.usage)
 
-function getDialogContents(from: number = 1, to: number = -1) {
-  return chain.value.slice(from, to).map(id => messageMap.value[id].message_contents).flat()
-}
-
-// const systemSdkModel = computed(() => getSdkModel(perfs.systemProvider, perfs.systemModel))
-
-// async function genTitle() {
-//   try {
-//     const dialogId = props.id
-//     const { text } = await generateText({
-//       model: systemSdkModel.value,
-//       prompt: await engine.parseAndRender(GenDialogTitle, {
-//         contents: getDialogContents(),
-//         lang: locale.value
-//       })
-//     })
-//     await dialogsStore.updateDialog({ id: dialogId, name: text })
-//   } catch (e) {
-//     console.error(e)
-//     $q.notify({ message: t('dialogView.summarizeFailed'), color: 'negative' })
-//   }
-// }
 async function copyContent() {
   await navigator.clipboard.writeText(await engine.parseAndRender(DialogContent, {
     contents: getDialogContents(),
@@ -1339,58 +898,6 @@ if (isPlatformEnabled(perfs.enableShortcutKey)) {
   useListenKey(toRef(perfs, 'focusDialogInputKey'), () => focusInput())
 }
 
-// async function genArtifactName(content: string, lang?: string) {
-//   const { text } = await generateText({
-//     model: systemSdkModel.value,
-//     prompt: engine.parseAndRenderSync(NameArtifactPrompt, { content, lang })
-//   })
-//   return text
-// }
-// const { createArtifact } = useCreateArtifact(toRef(workspace.value, 'id'))
-
-// async function extractArtifact(message: DialogMessageMapped, text: string, pattern, options: ConvertArtifactOptions) {
-//   const name = options.name || await genArtifactName(text, options.lang)
-//   const id = await createArtifact({
-//     name,
-//     language: options.lang,
-//     versions: [{
-//       date: new Date().toISOString(),
-//       text
-//     }],
-//     tmp: text
-//   })
-//   if (options.reserveOriginal) return
-//   const to = `> ${t('dialogView.convertedToArtifact')}: <router-link to="?openArtifact=${id}">${name}</router-link>\n`
-//   const index = message.message_contents.findIndex(c => ['assistant-message', 'user-message'].includes(c.type))
-
-//   await dialogsStore.updateDialogMessage(props.id, message.id, {
-//     message_contents: message.message_contents.map((c, i) => i === index ? {
-//       ...c,
-//       text: c.text.replace(pattern, to)
-//     } : c)
-//   })
-// }
-// async function autoExtractArtifact() {
-//   const message = messageMap.value[chain.value.at(-2)]
-//   const { text } = await generateText({
-//     model: systemSdkModel.value,
-//     prompt: engine.parseAndRenderSync(ExtractArtifactPrompt, {
-//       contents: chain.value.slice(-3, -1).map(id => messageMap.value[id].message_contents).flat()
-//     })
-//   })
-//   const object: ExtractArtifactResult = JSON.parse(text)
-//   if (!object.found) return
-//   const reg = new RegExp(`(\`{3,}.*\\n)?(${object.regex})(\\s*\`{3,})?`)
-//   const content = message.message_contents.find(c => c.type === 'assistant-message')
-//   const match = content.text.match(reg)
-//   if (!match) return
-//   await extractArtifact(message, match[2], reg, {
-//     name: object.name,
-//     lang: object.language,
-//     reserveOriginal: perfs.artifactsReserveOriginal
-//   })
-// }
-
 const uiStateStore = useUiStateStore()
 const scrollTops = uiStateStore.dialogScrollTops
 function onScroll(ev) {
@@ -1402,8 +909,6 @@ watch(() => dialog.value?.id, id => {
     scrollContainer.value?.scrollTo({ top: scrollTops[id] ?? 0 })
   })
 })
-
-const { createDialog } = useCreateDialog(workspace.value.id)
 
 defineEmits(['toggle-drawer'])
 

--- a/src/views/DialogView.vue
+++ b/src/views/DialogView.vue
@@ -421,11 +421,11 @@ const dialogsStore = useDialogsStore()
 const dialog = computed(() => dialogsStore.dialogs[props.id])
 const { switchChain, updateMsgRoute } = useDialogChain(dialog)
 const {
-  chain, messageMap, itemMap,
+  chain, messageMap,
   editBranch, deleteBranch, updateInputText,
   inputMessageContent, inputContentItems, addInputItems, inputEmpty, getDialogContents, removeStoredItem
 } = useDialogView(dialog, assistant, workspace)
-console.log('-- dialog', dialog.value, chain.value, messageMap.value, itemMap.value)
+
 const pluginsStore = usePluginsStore()
 
 const { model, sdkModel, modelOptions } = useDialogModel(dialog, assistant)

--- a/src/views/DialogView.vue
+++ b/src/views/DialogView.vue
@@ -401,14 +401,11 @@ import ModelOptionsBtn from 'src/components/ModelOptionsBtn.vue'
 import AddInfoBtn from 'src/components/AddInfoBtn.vue'
 import { useI18n } from 'vue-i18n'
 import Mark from 'mark.js'
-import { useCreateDialog } from 'src/composables/create-dialog'
 import EnablePluginsMenu from 'src/components/EnablePluginsMenu.vue'
 import { useUiStateStore } from 'src/stores/ui-state'
 import { useDialogsStore } from 'src/stores/dialogs'
-import { StoredItemMapped } from '@/services/supabase/types'
 import { useActiveWorkspace } from 'src/composables/workspaces/useActiveWorkspace'
 import { useLlmDialog } from 'src/composables/llm/useLlmDialog'
-import { useAssistantTools } from 'src/composables/llm/useAssistantTools'
 import { useDialogChain, useDialogModel, useDialogView } from 'src/composables/useDialogView'
 const { t, locale } = useI18n()
 
@@ -608,6 +605,7 @@ async function send() {
   nextTick().then(() => {
     scroll('bottom')
   })
+  console.log('-- inputEmpty', inputEmpty.value)
   if (inputEmpty.value) {
     await startStream(chain.value.at(-2), true)
   } else {

--- a/src/views/DialogView.vue
+++ b/src/views/DialogView.vue
@@ -25,6 +25,7 @@
         name="sym_o_expand_more"
         size="sm"
       /> -->
+      <!-- TODO: Refactor/remove model menu -->
       <q-menu important:max-w="300px">
         <q-list>
           <template v-if="assistant.model">
@@ -604,17 +605,13 @@ async function send() {
   // }
 
   showVars.value = false
+  nextTick().then(() => {
+    scroll('bottom')
+  })
   if (inputEmpty.value) {
     await startStream(chain.value.at(-2), true)
   } else {
-    const target = chain.value.at(-1)
-    await dialogsStore.updateDialogMessage(props.id, target, { status: 'default' })
-    until(chain).changed().then(() => {
-      nextTick().then(() => {
-        scroll('bottom')
-      })
-    })
-    await startStream(target, false)
+    await startStream(chain.value.at(-1), false)
   }
 }
 

--- a/src/views/PluginSettings.vue
+++ b/src/views/PluginSettings.vue
@@ -126,6 +126,7 @@ import ErrorNotFound from 'src/pages/ErrorNotFound.vue'
 import ListInput from 'src/components/ListInput.vue'
 import JsonInput from 'src/components/JsonInput.vue'
 import { useSetTitle } from 'src/composables/set-title'
+import { storeToRefs } from 'pinia'
 
 const props = defineProps<{
   id: string
@@ -134,7 +135,7 @@ const props = defineProps<{
 defineEmits(['toggle-drawer'])
 
 const pluginsStore = usePluginsStore()
-const { data } = pluginsStore
+const { data } = storeToRefs(pluginsStore)
 
 const plugin = computed(() => pluginsStore.plugins.find(p => p.id === props.id))
 


### PR DESCRIPTION
This pull request introduces several changes to improve type consistency across the codebase, refactor the handling of workspace and dialog objects, and add new functionality for assistant tools. The most significant changes involve replacing existing types with their mapped counterparts, refining function signatures, and implementing a new composable for assistant tools.

### Type Consistency Improvements:

* Replaced `StoredItem` with `StoredItemMapped` across multiple files (`src/common/types/dialogs.ts`, `src/components/AddInfoBtn.vue`, `src/components/MessageFile.vue`, `src/components/ToolContent.vue`). [[1]](diffhunk://#diff-a96bc73f145445ca61e0b2b59fdc64f5e34a55fef22f291e111bc264fa895b36L1-R6) [[2]](diffhunk://#diff-bba133e5daa9e261579b1155fb754855830506f7ba97a9544bdc132c7601d987L53-R53) [[3]](diffhunk://#diff-91d6e7bd1dc3333c1395f68b4efd30bc9c5166fe74a0847da54851486beb813eL15-R21) [[4]](diffhunk://#diff-5a4bd917d4f5e38c62de766b77f2afc6e551029a8589abeb47089cba378c1196L92-R92)
* Updated `Dialog` and `Workspace` types to `DialogMapped` and `WorkspaceMapped` in `src/components/AddInfoBtn.vue`. [[1]](diffhunk://#diff-bba133e5daa9e261579b1155fb754855830506f7ba97a9544bdc132c7601d987L53-R53) [[2]](diffhunk://#diff-bba133e5daa9e261579b1155fb754855830506f7ba97a9544bdc132c7601d987L63-R64)

### Refactoring of Workspace and Dialog Handling:

* Refactored the `useCallApi` function to accept `Ref<WorkspaceMapped>` and `Ref<DialogMapped>` instead of destructured parameters. Adjusted related function signatures and removed unused methods. [[1]](diffhunk://#diff-27e007ae4ba2750233159e1ecf2e3fa12cdceac506c016367cf0614cd87d4df4L5-R9) [[2]](diffhunk://#diff-27e007ae4ba2750233159e1ecf2e3fa12cdceac506c016367cf0614cd87d4df4L25-R26) [[3]](diffhunk://#diff-27e007ae4ba2750233159e1ecf2e3fa12cdceac506c016367cf0614cd87d4df4L36-R42)
* Updated `src/components/AddInfoBtn.vue` to use the new `useCallApi` signature and removed destructured parameters in `callApi`.

### Assistant Tools Functionality:

* Added a new composable, `useAssistantTools`, to manage assistant plugins, tools, and system prompts. This includes utility functions for transforming API results and handling tool execution.

### Other Changes:

* Modified `.prettierrc` to disable semicolons (`"semi": false`).
* Adjusted `src/components/MessageItem.vue` to streamline handling of result and stored items. [[1]](diffhunk://#diff-e1d7c71b090833c0ee55c8d4315094d5d5dc6da1f37911183186fefbf00e42e6L126-R132) [[2]](diffhunk://#diff-e1d7c71b090833c0ee55c8d4315094d5d5dc6da1f37911183186fefbf00e42e6L143-R143)